### PR TITLE
Fix project to make it an installable package

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,7 +3,3 @@ mock>=1.0.1
 flake8>=2.1.0
 tox>=1.7.0
 codecov>=2.0.0
-django-model-utils>=2.0
-xmltodict
-python-decouple
-django-distill

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,28 @@ try:
 except ImportError:
     from distutils.core import setup
 
+__dir__ = os.path.dirname(__file__)
+
+
+def read_requirements(filename):
+    """
+    Parse a requirements file.
+
+    It doesn't support any vcs+ dependency.
+
+    :return: list of str for each package
+    """
+    data = []
+    filename = os.path.join(__dir__, filename)
+    with open(filename) as requirements:
+        required = requirements.read().splitlines()
+        for line in required:
+            if not line or line.startswith('#') or line.__contains__('#egg='):
+                continue
+            data.append(line)
+
+    return data
+
 
 def get_version(*file_paths):
     """Retrieves the version from openhub_django/__init__.py"""
@@ -43,34 +65,38 @@ if sys.argv[-1] == 'tag':
 
 readme = open('README.rst').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
+required = read_requirements('requirements.txt')
+test_required = read_requirements('requirements_test.txt')
 
-setup(
-    name='openhub-django',
-    version=version,
-    description="""Integrate openhub APIs with Django""",
-    long_description=readme + '\n\n' + history,
-    author='Shrikrishna Singh',
-    author_email='krishnasingh.ss30@gmail.com',
-    url='https://github.com/sks444/openhub-django',
-    packages=[
-        'openhub_django',
-    ],
-    include_package_data=True,
-    install_requires=["django-model-utils>=2.0",],
-    license="MIT",
-    zip_safe=False,
-    keywords='openhub-django',
-    classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Framework :: Django :: 1.11',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-    ],
-)
+if __name__ == '__main__':
+    setup(
+        name='openhub-django',
+        version=version,
+        description="""Integrate openhub APIs with Django""",
+        long_description=readme + '\n\n' + history,
+        author='Shrikrishna Singh',
+        author_email='krishnasingh.ss30@gmail.com',
+        url='https://github.com/sks444/openhub-django',
+        packages=[
+            'openhub_django',
+        ],
+        include_package_data=True,
+        install_requires=required,
+        tests_require=test_required,
+        license="MIT",
+        zip_safe=False,
+        keywords='openhub-django',
+        classifiers=[
+            'Development Status :: 3 - Alpha',
+            'Framework :: Django :: 1.11',
+            'Intended Audience :: Developers',
+            'License :: OSI Approved :: BSD License',
+            'Natural Language :: English',
+            'Programming Language :: Python :: 2',
+            'Programming Language :: Python :: 2.7',
+            'Programming Language :: Python :: 3',
+            'Programming Language :: Python :: 3.4',
+            'Programming Language :: Python :: 3.5',
+            'Programming Language :: Python :: 3.6',
+        ],
+    )

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8
 from __future__ import unicode_literals, absolute_import
 
+import os
+
 import django
 
 DEBUG = True
@@ -9,12 +11,7 @@ USE_TZ = True
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = "-#t-d1kx#a_l#5dt6qxpn2w)i8qfbn=-kth6g3m@xl=wa!!1uh"
 
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": ":memory:",
-    }
-}
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 INSTALLED_APPS = [
     "django.contrib.auth",
@@ -23,7 +20,33 @@ INSTALLED_APPS = [
     "openhub_django",
 ]
 
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": os.path.join(BASE_DIR, 'db.sqlite3'),
+    }
+}
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            os.path.join(BASE_DIR, 'openhub_django/templates'),
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
 SITE_ID = 1
+
+ROOT_URLCONF = 'openhub_django.urls'
 
 if django.VERSION >= (1, 10):
     MIDDLEWARE = ()


### PR DESCRIPTION
The added changes will read the requirements and test-requirements
from there respective files & will make sure that any user installing the
openhub-django package will also install its required requirements instead
of explicitly mentioning of requirements in user's project.
Currently, it doesn't install any of the vcs+ dependency. They're being
ignored for now.