### PR TITLE
 Add card display to detail webpages

### DIFF
--- a/openhub_django/static/css/openhub_django.css
+++ b/openhub_django/static/css/openhub_django.css
@@ -2,9 +2,16 @@ html, body {
   height: 100%;
   margin: 0;
 }
-
 .about-page {
   padding-right: 1em;
+}
+
+.collection a.collection-item.apply-flex  {
+  display: flex;
+}
+
+.flex-row-direction {
+  flex-direction: row;
 }
 
 .main-content {
@@ -51,6 +58,15 @@ html, body {
 
 .main-content .input-group h1 {
   margin-bottom: 0;
+}
+
+.object-details {
+  box-shadow: 0 0 10px 1px black;
+  padding: 2px 8px;
+  border-radius: 20px;
+  border: 0 darkgray solid;
+  background: transparent;
+  margin-top: 20px;
 }
 
 strong {

--- a/openhub_django/templates/openhub_django/affiliatedcommitter_detail.html
+++ b/openhub_django/templates/openhub_django/affiliatedcommitter_detail.html
@@ -10,13 +10,15 @@
 {% endblock %}
 
 {% block main-content %}
-  <h1>Committer {{ affiliatedcommitter.name }} details</h1>
-  <p><strong>Name:</strong> {{ affiliatedcommitter.name }}</p>
-  <p><strong>Organization:</strong> {{ affiliatedcommitter.org }}</p>
-  <p><strong>Kudos:</strong> {{ affiliatedcommitter.kudos }}</p>
-  <p><strong>Level:</strong> {{ affiliatedcommitter.level }}</p>
-  <p><strong>Most commits project:</strong> {{ affiliatedcommitter.most_commits.project }}</p>
-  <p><strong>Most commits date:</strong> {{ affiliatedcommitter.most_commits.date }}</p>
-  <p><strong>Most recent commits project:</strong> {{ affiliatedcommitter.most_recent_commit.project }}</p>
-  <p><strong>Most recent commits data:</strong> {{ affiliatedcommitter.most_recent_commit.date }}</p>
+  <div class="container main-content object-details">
+    <h1>Committer {{ affiliatedcommitter.name }} details</h1>
+    <p><strong>Name:</strong> {{ affiliatedcommitter.name }}</p>
+    <p><strong>Organization:</strong> {{ affiliatedcommitter.org }}</p>
+    <p><strong>Kudos:</strong> {{ affiliatedcommitter.kudos }}</p>
+    <p><strong>Level:</strong> {{ affiliatedcommitter.level }}</p>
+    <p><strong>Most commits project:</strong> {{ affiliatedcommitter.most_commits.project }}</p>
+    <p><strong>Most commits date:</strong> {{ affiliatedcommitter.most_commits.date }}</p>
+    <p><strong>Most recent commits project:</strong> {{ affiliatedcommitter.most_recent_commit.project }}</p>
+    <p><strong>Most recent commits data:</strong> {{ affiliatedcommitter.most_recent_commit.date }}</p>
+  </div>
 {% endblock %}

--- a/openhub_django/templates/openhub_django/organization_detail.html
+++ b/openhub_django/templates/openhub_django/organization_detail.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block main-content %}
-  <div class="container main-content">
+  <div class="container main-content object-details">
     <h1><img src="{{ organization.small_logo_url }}" alt="{{ organization.name }}"> {{ organization.name }} organization summary</h1>
     <p><strong>Organization name:</strong> <a href="{{ organization.html_url }}" target="_blank">{{ organization.name }}</a></p>
     <p><strong>Homepage:</strong> <a href="{{ organization.homepage_url }}">{{ organization.homepage_url }}</a></p>

--- a/openhub_django/templates/openhub_django/organization_list.html
+++ b/openhub_django/templates/openhub_django/organization_list.html
@@ -29,9 +29,10 @@
     {% if organization_list %}
     <div class="collection">
       {% for organization in organization_list %}
-      <a href="{{ organization.get_absolute_url }}" class="collection-item" id="{{ organization.name }}">
+      <a href="{{ organization.get_absolute_url }}"
+         class="collection-item apply-flex flex-row-direction" id="{{ organization.name }}">
         <img src="{{ organization.small_logo_url }}" alt="{{ organization.name }}"/>
-        {{ organization.name }}
+        <span style="padding: 5px;">{{ organization.name }}</span>
       </a>
       {% endfor %}{# for organization in organization_list #}
     </div>

--- a/openhub_django/templates/openhub_django/outsidecommitter_detail.html
+++ b/openhub_django/templates/openhub_django/outsidecommitter_detail.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block main-content %}
-  <div class="container main-content">
+  <div class="container main-content object-details">
     <h1>Committer {{ outsidecommitter.name }} Details</h1>
     <p><strong>Name:</strong> {{ outsidecommitter.name }}</p>
     <p><strong>Org:</strong> {{ outsidecommitter.org }}</p>

--- a/openhub_django/templates/openhub_django/outsideproject_detail.html
+++ b/openhub_django/templates/openhub_django/outsideproject_detail.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block main-content %}
-  <div class="container main-content">
+  <div class="container main-content object-details">
     <h1>{{ outsideproject.name }} project details</h1>
     <p><strong>Name:</strong> {{ outsideproject.name }}</p>
     <p><strong>Activity:</strong> {{ outsideproject.activity }}</p>

--- a/openhub_django/templates/openhub_django/portfolioproject_detail.html
+++ b/openhub_django/templates/openhub_django/portfolioproject_detail.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block main-content %}
-  <div class="container main-content">
+  <div class="container main-content object-details">
     <h1>{{ portfolioproject.name }} project details</h1>
     <p><strong>Name:</strong> {{ portfolioproject.name }}</p>
     <p><strong>Activity:</strong> {{ portfolioproject.activity }}</p>


### PR DESCRIPTION
The commits improves the details webpage, which used to display an object
details.

![](https://user-images.githubusercontent.com/35761292/62680489-f9ffb180-b9d4-11e9-8442-24a03c00d689.png)

